### PR TITLE
fix(monitor): getting timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.1.3
+- resource monitor: fix getting timeout (by [@kevincali](https://github.com/kevincali))
+
 # v1.1.2
 - build: add support for darwin_arm64 by [@paretl]
 - go: upgrade to version 1.17 [@paretl]

--- a/uptimerobot/api/monitor.go
+++ b/uptimerobot/api/monitor.go
@@ -146,6 +146,7 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 	m.Type = intToString(monitorType, int(monitor["type"].(float64)))
 	m.Status = intToString(monitorStatus, int(monitor["status"].(float64)))
 	m.Interval = int(monitor["interval"].(float64))
+	m.Timeout = int(monitor["timeout"].(float64))
 	m.HTTPMethod = intToString(monitorHTTPMethod, int(monitor["http_method"].(float64)))
 
 	switch m.Type {


### PR DESCRIPTION
The `timeout` was never mapped on `getMonitors`.

With following .tf code:
```terraform
resource "uptimerobot_monitor" "example" {
  interval      = 60
  timeout       = 60
  type          = "http"
  http_method   = "GET"
  friendly_name = "Example"
  url           = "https://example.com"
}
```

I recevied following terraform plan, although on UptimeRobot.com the Timeout is set to 60sec:
```
  # uptimerobot_monitor.example will be updated in-place
  ~ resource "uptimerobot_monitor" "example" {
        id                  = "123456789"
      ~ timeout             = 0 -> 60
        # (17 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```

After the change I receive following plan:
```
No changes. Your infrastructure matches the configuration.
```