### PR TITLE
Update alert_contact.go to perform client-side filtering

### DIFF
--- a/uptimerobot/api/alert_contact.go
+++ b/uptimerobot/api/alert_contact.go
@@ -95,18 +95,19 @@ func (client UptimeRobotApiClient) GetAlertContacts() (acs []AlertContact, err e
 }
 
 func (client UptimeRobotApiClient) GetAlertContact(id string) (ac AlertContact, err error) {
+	// Initialize the return struct with the requested ID
 	ac.ID = id
-	data := url.Values{}
-	data.Add("alert_contacts", id)
-
+	
+	// Make API call without filtering (since the API doesn't support it properly)
 	body, err := client.MakeCall(
 		"getAlertContacts",
-		data.Encode(),
+		"", // No filter parameters
 	)
 	if err != nil {
 		return
 	}
 
+	// Extract the alert_contacts array from the response
 	alertcontacts, ok := body["alert_contacts"].([]interface{})
 	if !ok {
 		j, _ := json.Marshal(body)
@@ -114,12 +115,35 @@ func (client UptimeRobotApiClient) GetAlertContact(id string) (ac AlertContact, 
 		return
 	}
 
-	alertcontact := alertcontacts[0].(map[string]interface{})
+	// Find the alert contact with the matching ID
+	found := false
+	for _, contact := range alertcontacts {
+		alertcontact, ok := contact.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		
+		// Check if this is the alert contact we're looking for
+		contactID, ok := alertcontact["id"].(string)
+		if !ok {
+			continue
+		}
+		
+		if contactID == id {
+			// Found the matching alert contact, extract its details
+			ac.FriendlyName = alertcontact["friendly_name"].(string)
+			ac.Value = alertcontact["value"].(string)
+			ac.Type = intToString(alertContactType, int(alertcontact["type"].(float64)))
+			ac.Status = intToString(alertContactStatus, int(alertcontact["status"].(float64)))
+			found = true
+			break
+		}
+	}
 
-	ac.FriendlyName = alertcontact["friendly_name"].(string)
-	ac.Value = alertcontact["value"].(string)
-	ac.Type = intToString(alertContactType, int(alertcontact["type"].(float64)))
-	ac.Status = intToString(alertContactStatus, int(alertcontact["status"].(float64)))
+	// Return an error if the alert contact wasn't found
+	if !found {
+		err = errors.New("Alert contact with ID " + id + " not found")
+	}
 
 	return
 }


### PR DESCRIPTION
This is a workaround for the bug identified in https://github.com/mindee/terraform-provider-uptimerobot/issues/6

The getAlertContacts method on UptimeRobot public API has a bug and does not properly support filtering by alert contact id. However, we can easily implement this ourselves by filtering for the alert contact id from the response containing all the ids. https://uptimerobot.com/api/#getAlertContactsWrap

I will note that the code as written does not correctly handle the case where the user has more than 50 alert contacts since the API is paginated. I am not a go expert so would welcome feedback on whether addressing this limitation is in scope for this PR. For example, we could paginate over all the pages of alert contact responses and check if the desired id is present, failing only after the last page. 